### PR TITLE
Override or add configuration options in values input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  TERRAFORM_DOCS_VERSION: "v0.11.2"
+  TERRAFORM_DOCS_VERSION: "v0.15.0"
   TFLINT_VERSION: "v0.25.0"
   TFSEC_VERSION: "v0.39.6"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #    - id: terraform_tfsec
     - id: terraform_docs
       args:
-        - '--args=--hide providers --sort-by-required'
+        - '--args=--hide providers --sort-by required'
 
   - repo: git://github.com/pecigonzalo/pre-commit-terraform-vars
     rev: v1.0.0

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Check out these related projects.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
@@ -44,14 +42,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.prometheus_node_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"prometheus-node-exporter"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"2.0.3"` | no |

--- a/README.md
+++ b/README.md
@@ -29,37 +29,42 @@ Check out these related projects.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.0 |
-| helm | >= 1.0 |
-| kubernetes | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
+| Name | Type |
+|------|------|
+| [helm_release.prometheus_node_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
-| helm\_chart\_name | Helm chart name to be installed | `string` | `"prometheus-node-exporter"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"1.15.0"` | no |
-| helm\_release\_name | Helm release name | `string` | `"prometheus-node-exporter"` | no |
-| helm\_repo\_url | Helm repository | `string` | `"https://prometheus-community.github.io/helm-charts"` | no |
-| k8s\_namespace | The K8s namespace in which the prometheus-node-exporter service account has been created | `string` | `"kube-system"` | no |
-| mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
-| settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/prometheus-node-exporter | `map(any)` | `{}` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
+| <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"prometheus-node-exporter"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"2.0.3"` | no |
+| <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"prometheus-node-exporter"` | no |
+| <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://prometheus-community.github.io/helm-charts"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the prometheus-node-exporter service account has been created | `string` | `"kube-system"` | no |
+| <a name="input_mod_dependency"></a> [mod\_dependency](#input\_mod\_dependency) | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/prometheus-node-exporter | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart. | `string` | `""` | no |
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"prometheus-node-exporter"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"2.0.3"` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"prometheus-node-exporter"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://prometheus-community.github.io/helm-charts"` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the prometheus-node-exporter service account has been created | `string` | `"kube-system"` | no |
-| <a name="input_mod_dependency"></a> [mod\_dependency](#input\_mod\_dependency) | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/prometheus-node-exporter | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart. | `string` | `""` | no |
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,23 +11,23 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| eks_cluster | cloudposse/eks-cluster/aws |  |
-| eks_workers | cloudposse/eks-workers/aws |  |
-| prometheus_node_exporter | ../../ |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
+| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_prometheus_node_exporter"></a> [prometheus\_node\_exporter](#module\_prometheus\_node\_exporter) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) |
-| [aws_eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) |
+| Name | Type |
+|------|------|
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,10 +11,10 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
-| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.43.2 |
+| <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 0.25.0 |
 | <a name="module_prometheus_node_exporter"></a> [prometheus\_node\_exporter](#module\_prometheus\_node\_exporter) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.6.0 |
 
 ## Resources
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -39,6 +39,4 @@ module "eks_workers" {
 
 module "prometheus_node_exporter" {
   source = "../../"
-
-  cluster_name = module.eks_cluster.eks_cluster_id
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -14,7 +14,7 @@ module "eks_cluster" {
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "node-problem-detector"
+  name       = "prometheus-node-exporter"
 
   workers_security_group_ids = [module.eks_workers.security_group_id]
   workers_role_arns          = [module.eks_workers.workers_role_arn]
@@ -25,8 +25,7 @@ module "eks_workers" {
 
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = module.eks_cluster.eks_cluster_id
-  cluster_security_group_id          = module.eks_cluster.security_group_id
+  cluster_name                       = "prometheus-node-exporter"
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1
@@ -40,4 +39,6 @@ module "eks_workers" {
 
 module "prometheus_node_exporter" {
   source = "../../"
+
+  cluster_name = module.eks_cluster.eks_cluster_id
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,8 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
 
-  name               = "node-problem-detector-vpc"
+  name               = "metrics-server-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
@@ -9,33 +10,27 @@ module "vpc" {
 }
 
 module "eks_cluster" {
-  source = "cloudposse/eks-cluster/aws"
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.43.2"
 
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "prometheus-node-exporter"
-
-  workers_security_group_ids = [module.eks_workers.security_group_id]
-  workers_role_arns          = [module.eks_workers.workers_role_arn]
+  name       = "metrics-server"
 }
 
-module "eks_workers" {
-  source = "cloudposse/eks-workers/aws"
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.25.0"
 
-  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
-  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = "prometheus-node-exporter"
-  instance_type                      = "t3.medium"
-  max_size                           = 1
-  min_size                           = 1
-  subnet_ids                         = module.vpc.public_subnets
-  vpc_id                             = module.vpc.vpc_id
-
-  associate_public_ip_address = true
+  cluster_name   = "metrics-server"
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
 }
-
-# Use the module:
 
 module "prometheus_node_exporter" {
   source = "../../"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.6.0"
 
-  name               = "metrics-server-vpc"
+  name               = "node-exporter-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
@@ -16,14 +16,14 @@ module "eks_cluster" {
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "metrics-server"
+  name       = "node-exporter"
 }
 
 module "eks_node_group" {
   source  = "cloudposse/eks-node-group/aws"
   version = "0.25.0"
 
-  cluster_name   = "metrics-server"
+  cluster_name   = "node-exporter"
   instance_types = ["t3.medium"]
   subnet_ids     = module.vpc.public_subnets
   min_size       = 1

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -10,12 +10,6 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_cluster.eks_cluster_id
 }
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.this.endpoint

--- a/main.tf
+++ b/main.tf
@@ -1,22 +1,3 @@
-locals {
-  values = yamlencode({
-    "awsRegion" : data.aws_region.current.name,
-    "autoDiscovery" : {
-      "clusterName" : var.cluster_name
-    },
-  })
-}
-
-data "aws_region" "current" {}
-
-data "utils_deep_merge_yaml" "values" {
-  count = var.enabled ? 1 : 0
-  input = compact([
-    local.values,
-    var.values
-  ])
-}
-
 resource "helm_release" "prometheus_node_exporter" {
   count            = var.enabled ? 1 : 0
   chart            = var.helm_chart_name
@@ -27,7 +8,7 @@ resource "helm_release" "prometheus_node_exporter" {
   repository       = var.helm_repo_url
 
   values = [
-    data.utils_deep_merge_yaml.values[0].output
+    var.values
   ]
 
   dynamic "set" {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,22 @@
+locals {
+  values = yamlencode({
+    "awsRegion" : data.aws_region.current.name,
+    "autoDiscovery" : {
+      "clusterName" : var.cluster_name
+    },
+  })
+}
+
+data "aws_region" "current" {}
+
+data "utils_deep_merge_yaml" "values" {
+  count = var.enabled ? 1 : 0
+  input = compact([
+    local.values,
+    var.values
+  ])
+}
+
 resource "helm_release" "prometheus_node_exporter" {
   depends_on = [var.mod_dependency]
   count      = var.enabled ? 1 : 0
@@ -6,6 +25,10 @@ resource "helm_release" "prometheus_node_exporter" {
   name       = var.helm_release_name
   version    = var.helm_chart_version
   repository = var.helm_repo_url
+
+  values = [
+    data.utils_deep_merge_yaml.values[0].output
+  ]
 
   dynamic "set" {
     for_each = var.settings

--- a/main.tf
+++ b/main.tf
@@ -18,13 +18,13 @@ data "utils_deep_merge_yaml" "values" {
 }
 
 resource "helm_release" "prometheus_node_exporter" {
-  depends_on = [var.mod_dependency]
-  count      = var.enabled ? 1 : 0
-  chart      = var.helm_chart_name
-  namespace  = var.k8s_namespace
-  name       = var.helm_release_name
-  version    = var.helm_chart_version
-  repository = var.helm_repo_url
+  count            = var.enabled ? 1 : 0
+  chart            = var.helm_chart_name
+  create_namespace = var.helm_create_namespace
+  namespace        = var.k8s_namespace
+  name             = var.helm_release_name
+  version          = var.helm_chart_version
+  repository       = var.helm_repo_url
 
   values = [
     data.utils_deep_merge_yaml.values[0].output

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "1.15.0"
+  default     = "2.0.3"
   description = "Version of the Helm chart"
 }
 
@@ -50,4 +50,15 @@ variable "settings" {
   type        = map(any)
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/prometheus-node-exporter"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+variable "values" {
+  type        = string
+  default     = ""
+  description = "Additional yaml encoded values which will be passed to the Helm chart."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "enabled" {
 
 # Helm
 
+variable "helm_create_namespace" {
+  type        = bool
+  default     = true
+  description = "Create the namespace if it does not yet exist"
+}
+
 variable "helm_chart_name" {
   type        = string
   default     = "prometheus-node-exporter"
@@ -38,12 +44,6 @@ variable "k8s_namespace" {
   type        = string
   default     = "kube-system"
   description = "The K8s namespace in which the prometheus-node-exporter service account has been created"
-}
-
-variable "mod_dependency" {
-  type        = bool
-  default     = null
-  description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
 }
 
 variable "settings" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,11 +52,6 @@ variable "settings" {
   description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/prometheus-node-exporter"
 }
 
-variable "cluster_name" {
-  type        = string
-  description = "The name of the cluster"
-}
-
 variable "values" {
   type        = string
   default     = ""

--- a/versions.tf
+++ b/versions.tf
@@ -10,13 +10,5 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
-    utils = {
-      source  = "cloudposse/utils"
-      version = ">= 0.12.0"
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,9 +10,13 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 1.10"
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.12.0"
     }
   }
 }


### PR DESCRIPTION
Changes:
* Add ability to override or add configuration options in default values 
* Delegate Kubernetes namespace creation to helm provider from Kubernetes provider
* Remove fake dependency variable in favor of terraform built-in module dependency
* Bump default chart version to the 2.0.3 

Breaking changes:
* Removes fake dependency variable `mod_dependency` in favor of terraform built-in module dependency injection

Signed-off-by: Ondřej Šmalec <ondrej.smalec@lablabs.io>